### PR TITLE
[#2] Fastlane tests

### DIFF
--- a/UITests.xctestplan
+++ b/UITests.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "E8BED382-5ADA-46FA-B318-2556C5C5A000",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:iOS Platform Assessment.xcodeproj",
+        "identifier" : "EFC1F9A82DAF1C47003FF9A9",
+        "name" : "iOS Platform AssessmentUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "C9670586-1D96-43F4-9FD2-F0A09FC51899",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:iOS Platform Assessment.xcodeproj",
+        "identifier" : "EFC1F99E2DAF1C47003FF9A9",
+        "name" : "iOS Platform AssessmentTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,16 +13,47 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+RUN_ID = is_ci ? ENV["RUN_ID"] : "local"
+
+PROJECT_PATH = "iOS Platform Assessment.xcodeproj"
+TEST_DEVICE = "iPhone 16 Pro (18.4)"
+
+ROOT_PATH = File.expand_path("../", File.dirname(__FILE__))
+CONFIG_PATH = File.join(ROOT_PATH, "Config")
+BUILD_PATH = File.join(ROOT_PATH, "build")
+REPORTS_PATH = File.join(BUILD_PATH, "reports")
+RUN_PATH = File.join(REPORTS_PATH, RUN_ID || "local")
+
 default_platform(:ios)
 
 platform :ios do
   desc "A custom fastlane lane to run the unit tests"
   lane :unit_tests do
-    # add actions here: https://docs.fastlane.tools/actions
+    run_tests(
+      buildlog_path: RUN_PATH,
+      clean: true,  
+      code_coverage: true,
+      device: TEST_DEVICE,
+      ensure_devices_found: true,
+      derived_data_path: RUN_PATH,
+      cloned_source_packages_path: "SourcePackages",
+      project: PROJECT_PATH,
+      testplan: "UnitTests"
+    )
   end
 
   desc "A custom fastlane lane to run the UI tests"
   lane :ui_tests do
-    # add actions here: https://docs.fastlane.tools/actions
+    run_tests(
+      buildlog_path: RUN_PATH,
+      clean: true,  
+      code_coverage: true,
+      device: TEST_DEVICE,
+      ensure_devices_found: true,
+      derived_data_path: RUN_PATH,
+      cloned_source_packages_path: "SourcePackages",
+      project: PROJECT_PATH,
+      testplan: "UITests"
+    )
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,40 @@
+fastlane documentation
+----
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
+```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+# Available Actions
+
+## iOS
+
+### ios unit_tests
+
+```sh
+[bundle exec] fastlane ios unit_tests
+```
+
+A custom fastlane lane to run the unit tests
+
+### ios ui_tests
+
+```sh
+[bundle exec] fastlane ios ui_tests
+```
+
+A custom fastlane lane to run the UI tests
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/iOS Platform Assessment.xcodeproj/project.pbxproj
+++ b/iOS Platform Assessment.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D4A416712E08C8A000A13B2A /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
+		D4A416722E08C8AF00A13B2A /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
 		EFC1F98F2DAF1C46003FF9A9 /* iOS Platform Assessment.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS Platform Assessment.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFC1F99F2DAF1C47003FF9A9 /* iOS Platform AssessmentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Platform AssessmentTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFC1F9A92DAF1C47003FF9A9 /* iOS Platform AssessmentUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Platform AssessmentUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -75,6 +77,8 @@
 		EFC1F9862DAF1C46003FF9A9 = {
 			isa = PBXGroup;
 			children = (
+				D4A416722E08C8AF00A13B2A /* UITests.xctestplan */,
+				D4A416712E08C8A000A13B2A /* UnitTests.xctestplan */,
 				EFC1F9912DAF1C46003FF9A9 /* iOS Platform Assessment */,
 				EFC1F9A22DAF1C47003FF9A9 /* iOS Platform AssessmentTests */,
 				EFC1F9AC2DAF1C47003FF9A9 /* iOS Platform AssessmentUITests */,

--- a/iOS Platform Assessment.xcodeproj/xcshareddata/xcschemes/iOS Platform Assessment.xcscheme
+++ b/iOS Platform Assessment.xcodeproj/xcshareddata/xcschemes/iOS Platform Assessment.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EFC1F98E2DAF1C46003FF9A9"
+               BuildableName = "iOS Platform Assessment.app"
+               BlueprintName = "iOS Platform Assessment"
+               ReferencedContainer = "container:iOS Platform Assessment.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:UITests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EFC1F99E2DAF1C47003FF9A9"
+               BuildableName = "iOS Platform AssessmentTests.xctest"
+               BlueprintName = "iOS Platform AssessmentTests"
+               ReferencedContainer = "container:iOS Platform Assessment.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EFC1F9A82DAF1C47003FF9A9"
+               BuildableName = "iOS Platform AssessmentUITests.xctest"
+               BlueprintName = "iOS Platform AssessmentUITests"
+               ReferencedContainer = "container:iOS Platform Assessment.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EFC1F98E2DAF1C46003FF9A9"
+            BuildableName = "iOS Platform Assessment.app"
+            BlueprintName = "iOS Platform Assessment"
+            ReferencedContainer = "container:iOS Platform Assessment.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EFC1F98E2DAF1C46003FF9A9"
+            BuildableName = "iOS Platform Assessment.app"
+            BlueprintName = "iOS Platform Assessment"
+            ReferencedContainer = "container:iOS Platform Assessment.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
* Fills in lanes for unit tests and UI tests in Fastfile
* Added individual Xcode test plans to the scheme in Xcode so unit tests / UI tests can be run separately as intended
* Contains bundle updates, probably not necessary and typically would include as a separate PR
* Customized parameters in the lanes' calls to [`run_tests`](https://docs.fastlane.tools/actions/run_tests/) with the intent of having these run properly on CI machines (forcing build artifacts, reports etc to live inside the repo folder so they can be retrieved easily to be added as attachments when runs fail)