### PR TITLE
Vehicles pagination

### DIFF
--- a/iOS Platform Assessment/APIModels.swift
+++ b/iOS Platform Assessment/APIModels.swift
@@ -10,6 +10,13 @@ import Foundation
 /// Vehicles
 
 struct VehiclesResponse: Decodable {
+  // MARK - Pagination
+  let startCursor: String
+  let nextCursor: String?
+  let perPage: Int
+  let estimatedRemainingCount: Int
+  
+  // MARK: - Vehicles
   let records: [Vehicle]
   
   /// Workaround for `year` being a number when a string is expected, remove when fixed

--- a/iOS Platform Assessment/NetworkHelper.swift
+++ b/iOS Platform Assessment/NetworkHelper.swift
@@ -46,8 +46,8 @@ struct NetworkHelper: DataProvider {
     }
     
     var request = URLRequest(url: vehiclesURL)
-    request.addValue(accountToken, forHTTPHeaderField: "Account-Token") // FIXME: get token from login
-    request.addValue("Token \(apiKey)", forHTTPHeaderField: "Authorization") // FIXME: get API key from login
+    request.addValue(accountToken, forHTTPHeaderField: "Account-Token")
+    request.addValue("Token \(apiKey)", forHTTPHeaderField: "Authorization")
     
     
     let (data, _) = try await URLSession.shared.data(for: request)

--- a/iOS Platform Assessment/NetworkHelper.swift
+++ b/iOS Platform Assessment/NetworkHelper.swift
@@ -8,14 +8,19 @@
 import Foundation
 
 protocol DataProvider {
-  func getVehicles() async throws -> [Vehicle]
+  func getVehicles(startCursor: String?) async throws -> (results: [Vehicle], paging: Paging)
+}
+
+struct Paging {
+  let nextCursor: String?
+  let estimatedRemainingCount: Int
 }
 
 struct NetworkHelper: DataProvider {
   enum Endpoint {
     case vehicles
     case locationEntry(equipmentId: Int, locationEntryId: Int)
-    
+
     func url(base: String) -> URL? {
       let path: String = {
         switch self {
@@ -25,41 +30,52 @@ struct NetworkHelper: DataProvider {
           "vehicles/\(vehicleId)/location_entries/\(locationEntryId)"
         }
       }()
-        
-      return URL(string: base + path)
+
+      return URL(string: path, relativeTo: URL(string: base))
     }
   }
-  
+
   init(baseURL: String = .defaultAPIURL) {
     self.baseURL = baseURL
   }
-  
+
   let baseURL: String
-  
-  func getVehicles() async throws -> [Vehicle] {
-    guard let vehiclesURL = Endpoint.vehicles.url(base: baseURL) else {
+
+  func getVehicles(startCursor: String?) async throws -> (results: [Vehicle], paging: Paging) {
+    guard let vehiclesURL = Endpoint.vehicles.url(base: baseURL),
+          var components = URLComponents(url: vehiclesURL, resolvingAgainstBaseURL: true) else {
       throw NetworkError.invalidURL
     }
-    
+
+    if let startCursor {
+      components.queryItems = [
+        .init(name: "start_cursor", value: startCursor),
+      ]
+    }
+
+    guard let url = components.url else {
+      throw NetworkError.invalidURL
+    }
+
     guard let apiKey = CredentialStore.apiKey, let accountToken = CredentialStore.accountToken else {
       throw NetworkError.unauthorized
     }
-    
-    var request = URLRequest(url: vehiclesURL)
+
+    var request = URLRequest(url: url)
     request.addValue(accountToken, forHTTPHeaderField: "Account-Token")
     request.addValue("Token \(apiKey)", forHTTPHeaderField: "Authorization")
-    
-    
+
+
     let (data, _) = try await URLSession.shared.data(for: request)
-    
-//    let responseBody = String(data: data, encoding: .utf8) ?? "No readable data"
-//    print(responseBody)
-    
+
+    //    let responseBody = String(data: data, encoding: .utf8) ?? "No readable data"
+    //    print(responseBody)
+
     let decoder = DataDecoder()
-    
+
     return try decoder.decodeVehicles(data: data)
   }
-  
+
   enum NetworkError: Error {
     case invalidURL
     case unauthorized
@@ -72,17 +88,31 @@ struct DataDecoder {
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     return decoder
   }()
-  
-  func decodeVehicles(data: Data) throws -> [Vehicle] {
-    try decoder.decode(VehiclesResponse.self, from: data).records.vehicleModels
+
+  func decodeVehicles(data: Data) throws -> (results: [Vehicle], paging: Paging) {
+    let response = try decoder.decode(VehiclesResponse.self, from: data)
+    return (
+      response.records.vehicleModels,
+      .init(
+        nextCursor: response.nextCursor,
+        estimatedRemainingCount: response.estimatedRemainingCount
+      )
+    )
   }
 }
 
 struct SampleDataProvider: DataProvider {
   let mockNetworkDelaySeconds: Int = 2
-  func getVehicles() async throws -> [Vehicle] {
+  func getVehicles(startCursor: String?) async throws -> (results: [Vehicle], paging: Paging) {
     try? await Task.sleep(nanoseconds: UInt64(mockNetworkDelaySeconds) * 1_000_000_000)
-    return SampleData.vehicleList
+    // TODO: could implement paging with sample data as well
+    return (
+      SampleData.vehicleList,
+      .init(
+        nextCursor: nil,
+        estimatedRemainingCount: 0
+      )
+    )
   }
 }
 

--- a/iOS Platform Assessment/SampleData.swift
+++ b/iOS Platform Assessment/SampleData.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Vehicle {
+struct Vehicle: Equatable {
   let id: Int
   let name: String
   let model: String

--- a/iOS Platform Assessment/VehicleList.swift
+++ b/iOS Platform Assessment/VehicleList.swift
@@ -5,20 +5,36 @@ struct VehicleList: View {
   @Observable
   class ViewModel {
     var vehicles: [Vehicle] = []
-    
+    private var nextPage: Paging?
+
     private let dataProvider: DataProvider
-    
+
     init(dataProvider: DataProvider) {
       self.dataProvider = dataProvider
     }
-    
-    func fetchVehicles() async throws {
-      vehicles = try await dataProvider.getVehicles()
+
+    func fetchVehicles(shouldLoadNextPage: Bool = false) async throws {
+      if shouldLoadNextPage {
+        let (newPageOfVehicles, paging) = try await dataProvider.getVehicles(startCursor: nextPage?.nextCursor)
+        nextPage = paging
+        vehicles += newPageOfVehicles
+      } else {
+        (vehicles, nextPage) = try await dataProvider.getVehicles(startCursor: nil)
+      }
+    }
+
+    var hasMorePages: Bool {
+      nextPage?.estimatedRemainingCount ?? 0 > vehicles.count
+    }
+
+    func reset() {
+      nextPage = nil
+      vehicles.removeAll(keepingCapacity: true)
     }
   }
-  
+
   @Environment(ViewModel.self) private var viewModel
-  
+
   @State private var isLoading = true
   @State private var searchText = ""
   @State private var selectedVehicle: Vehicle?
@@ -41,42 +57,54 @@ struct VehicleList: View {
   }
 
   var body: some View {
-    Group {
-      if isLoading {
-        ProgressView()
-          .progressViewStyle(CircularProgressViewStyle())
-          .onAppear {
-            Task {
-              do {
-                try await viewModel.fetchVehicles()
-              } catch {
-                // TODO: error handling
-                print(error)
-              }
-              isLoading = false
-            }
+    VStack {
+      SearchBar(text: $searchText)
+        .padding()
+        .background(Color(UIColor.secondarySystemGroupedBackground))
+        .onChange(of: searchText) {
+          lastUpdated = Date()
+        }
+      List {
+        if isLoading {
+          ProgressView()
+            .progressViewStyle(CircularProgressViewStyle())
+            .frame(maxWidth: .infinity)
+        }
+        ForEach(filteredVehicles, id: \.id) { vehicle in
+          NavigationLink(destination: VehicleView(vehicle: vehicle)) {
+            VehicleRow(vehicle: vehicle)
           }
-      } else {
-        VStack {
-          SearchBar(text: $searchText)
-            .padding()
-            .background(Color(UIColor.secondarySystemGroupedBackground))
-            .onChange(of: searchText) { _ in
-              lastUpdated = Date()
-            }
-          List {
-            ForEach(filteredVehicles, id: \.id) { vehicle in
-              NavigationLink(destination: VehicleView(vehicle: vehicle)) {
-                VehicleRow(vehicle: vehicle)
-              }
-              .accessibilityIdentifier(AccessibilityIdentifiers.VehicleList.vehicleListItem(id: vehicle.id))
-              .background(selectedVehicle?.id == vehicle.id ? Color.gray.opacity(0.1) : Color.clear)
-            }
+          .accessibilityIdentifier(AccessibilityIdentifiers.VehicleList.vehicleListItem(id: vehicle.id))
+          .background(selectedVehicle?.id == vehicle.id ? Color.gray.opacity(0.1) : Color.clear)
+        }
+        if viewModel.hasMorePages {
+          Button("Load more") {
+            loadData(shouldLoadNextPage: true)
           }
-          .navigationTitle("Vehicles")
-          .navigationBarTitleDisplayMode(.inline)
         }
       }
+      .refreshable {
+        viewModel.reset()
+        loadData()
+      }
+      .navigationTitle("Vehicles")
+      .navigationBarTitleDisplayMode(.inline)
+    }
+    .onAppear {
+      loadData()
+    }
+  }
+
+  func loadData(shouldLoadNextPage: Bool = false) {
+    isLoading = true
+    Task {
+      do {
+        try await viewModel.fetchVehicles(shouldLoadNextPage: shouldLoadNextPage)
+      } catch {
+        // TODO: error handling
+        print(error)
+      }
+      isLoading = false
     }
   }
 }

--- a/iOS Platform AssessmentTests/APIDecodingTests.swift
+++ b/iOS Platform AssessmentTests/APIDecodingTests.swift
@@ -27,7 +27,10 @@ struct APIDecodingTests {
   @Test func vehicles() async throws {
     let decoder = DataDecoder()
     let data = try loadJSONFromFile(named: "Vehicles")
-    let vehicles = try decoder.decodeVehicles(data: data)
+    let (vehicles, paging) = try decoder.decodeVehicles(data: data)
+    
+    #expect(paging.nextCursor == "eyJpZCI6Mzk5MjMyMX0=")
+    #expect(paging.estimatedRemainingCount == 51)
 
     #expect(vehicles.count == 50)
     #expect(vehicles.first?.name == "2024 GMC Sierra 1500 SLT")


### PR DESCRIPTION
* Closes #5
* Added basic pagination implementation, could be cleaned up, doesn't expose
* the `estimated_remaining_count` behaves a bit weird in the API — for what I have it's always 51 on all pages; seems to be counting all the items in the query instead of just the ones in subsequent pages; unclear if this is a bug or not but I just worked around it
* Structure of the vehicle list view with the `Group` and the progress view was messing up the state such that changing the vehicle list reset the whole view. Cleaned that up here.
* Couple more lines in the API decoding unit test